### PR TITLE
Use cookies for user authentication

### DIFF
--- a/cmd/gitpod/web.go
+++ b/cmd/gitpod/web.go
@@ -22,6 +22,7 @@ const (
 	FlagAddr     = "addr"
 	FlagEnv      = "env"
 	FlagLogLevel = "loglevel"
+	FlagSecret   = "secret"
 
 	ProductionEnv = "production"
 )
@@ -45,12 +46,19 @@ var FlagsWeb = []cli.Flag{
 		Usage:  "The log level to filter logs with before printing",
 		Value:  "info",
 	},
+	cli.StringFlag{
+		Name:   FlagSecret,
+		EnvVar: "GITPOD_SECRET",
+		Usage:  "This secret is going to be used to generate cookies",
+		Value:  "secret", // TODO: Remove this to force users to pass a real secret, no default
+	},
 }
 
 func ActionWeb(c *cli.Context) error {
 	addr := c.String(FlagAddr)
 	env := c.String(FlagEnv)
 	loglevel := c.String(FlagLogLevel)
+	//secret := c.String(FlagSecret) TODO: Use this
 
 	// Create the logger based on the environment: production/development/test
 	logger := newLogger(env, loglevel)

--- a/cmd/gitpod/web.go
+++ b/cmd/gitpod/web.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/go-kit/kit/metrics/prometheus"
 	"github.com/gobuffalo/packr"
+	"github.com/gorilla/sessions"
 	"github.com/oklog/oklog/pkg/group"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"github.com/urfave/cli"
@@ -58,7 +59,7 @@ func ActionWeb(c *cli.Context) error {
 	addr := c.String(FlagAddr)
 	env := c.String(FlagEnv)
 	loglevel := c.String(FlagLogLevel)
-	//secret := c.String(FlagSecret) TODO: Use this
+	secret := c.String(FlagSecret)
 
 	// Create the logger based on the environment: production/development/test
 	logger := newLogger(env, loglevel)
@@ -67,11 +68,20 @@ func ActionWeb(c *cli.Context) error {
 	// The path is relative to this file.
 	box := packr.NewBox("../../public")
 
+	cookieStore := sessions.NewFilesystemStore("/tmp/gitpods_sessions", []byte(secret))
+
 	// Create a simple store running in memory for example purposes
 	userStore := store.NewUserInMemory()
 
+	// Create a routerStore by passing concrete implementations to interfaces for the router.
+	routerStore := handler.RouterStore{
+		CookieStore: cookieStore,
+		UserStore:   userStore,
+		LoginStore:  userStore,
+	}
+
 	// Create the http router and return it for use
-	r := handler.NewRouter(logger, prometheusMetrics(), box, userStore)
+	r := handler.NewRouter(logger, prometheusMetrics(), box, routerStore)
 
 	server := &http.Server{Addr: addr, Handler: r}
 

--- a/handler/authorize.go
+++ b/handler/authorize.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -14,27 +15,68 @@ import (
 )
 
 const (
+	// SessionName is the name used to store the cookie on the client
+	SessionName         = "_gitpods_session"
+	SessionUserID       = "user_id"
+	SessionUserUsername = "user_username"
+
 	loginAttemptFailed  = "failed"
 	loginAttemptSuccess = "success"
 )
 
-var (
-	BadCredentialsJson = map[string]string{"message": "Bad credentials"}
-	cookieStore        = sessions.NewCookieStore([]byte("secret"))
-)
-
 type LoginStore interface {
+	GetUser(string) (gitpod.User, error)
 	GetUserByEmail(string) (gitpod.User, error)
 }
 
-type loginForm struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
+// Authorized users will have a user information in the next handlers.
+func Authorized(logger log.Logger, cookies sessions.Store) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			session, err := cookies.Get(r, SessionName)
+			if err != nil {
+				level.Warn(logger).Log("msg", "can't get session from cookie store", "err", err)
+				jsonResponseBytes(w, JsonBadCredentials, http.StatusInternalServerError)
+				return
+			}
+
+			id, found := session.Values[SessionUserID]
+			if !found || id == "" {
+				level.Debug(logger).Log("msg", "user's id can't be found in session")
+				jsonResponseBytes(w, JsonUnauthorized, http.StatusUnauthorized)
+				return
+			}
+
+			username, found := session.Values[SessionUserUsername]
+			if !found || username == "" {
+				level.Debug(logger).Log("msg", "user's username can't be found in session")
+				jsonResponseBytes(w, JsonUnauthorized, http.StatusUnauthorized)
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), SessionUserID, id)
+			ctx = context.WithValue(r.Context(), SessionUserUsername, username)
+			r = r.WithContext(ctx)
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
-func Authorize(logger log.Logger, loginAttempts metrics.Counter, s LoginStore) http.HandlerFunc {
+func Authorize(logger log.Logger, loginAttempts metrics.Counter, cookies sessions.Store, s LoginStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var form loginForm
+		session, err := cookies.Get(r, SessionName)
+		if err != nil {
+			level.Warn(logger).Log("msg", "can't get session from cookie store", "err", err)
+			loginAttempts.With("status", loginAttemptFailed).Add(1)
+			jsonResponseBytes(w, JsonBadCredentials, http.StatusInternalServerError)
+			return
+		}
+
+		var form struct {
+			Email    string `json:"email"`
+			Password string `json:"password"`
+		}
 
 		if err := json.NewDecoder(r.Body).Decode(&form); err != nil {
 			level.Warn(logger).Log("msg", "failed to unmarshal form", "err", err)
@@ -47,13 +89,13 @@ func Authorize(logger log.Logger, loginAttempts metrics.Counter, s LoginStore) h
 		if err == store.UserNotFound {
 			level.Debug(logger).Log("msg", "user by email doesn't exist", "email", form.Email)
 			loginAttempts.With("status", loginAttemptFailed).Add(1)
-			jsonResponse(w, BadCredentialsJson, http.StatusUnauthorized)
+			jsonResponseBytes(w, JsonBadCredentials, http.StatusUnauthorized)
 			return
 		}
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to get user by email", "err", err)
 			loginAttempts.With("status", loginAttemptFailed).Add(1)
-			jsonResponse(w, BadCredentialsJson, http.StatusUnauthorized)
+			jsonResponseBytes(w, JsonBadCredentials, http.StatusUnauthorized)
 			return
 		}
 
@@ -61,21 +103,36 @@ func Authorize(logger log.Logger, loginAttempts metrics.Counter, s LoginStore) h
 		if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(form.Password)); err != nil {
 			level.Debug(logger).Log("msg", "login password doesn't match", "err", err)
 			loginAttempts.With("status", loginAttemptFailed).Add(1)
-			jsonResponse(w, BadCredentialsJson, http.StatusUnauthorized)
+			jsonResponseBytes(w, JsonBadCredentials, http.StatusUnauthorized)
+			return
+		}
+
+		session.Values[SessionUserID] = user.ID
+		session.Values[SessionUserUsername] = user.Username
+
+		if err := session.Save(r, w); err != nil {
+			level.Warn(logger).Log("msg", "can't save session to cookie store", "err", err)
+			loginAttempts.With("status", loginAttemptFailed).Add(1)
+			jsonResponseBytes(w, JsonBadCredentials, http.StatusInternalServerError)
 			return
 		}
 
 		loginAttempts.With("status", loginAttemptSuccess).Add(1)
-
 		jsonResponse(w, user, http.StatusOK)
 	}
 }
 
 func AuthorizedUser(logger log.Logger, s LoginStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		user, err := s.GetUserByEmail("metalmatze@example.com") // TODO: Get username or id from some token
+		username := r.Context().Value(SessionUserUsername)
+		if username == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		user, err := s.GetUser(username.(string))
 		if err == store.UserNotFound {
-			jsonResponse(w, NotFoundJson, http.StatusNotFound)
+			jsonResponseBytes(w, JsonNotFound, http.StatusNotFound)
 			return
 		}
 		if err != nil {

--- a/handler/authorize.go
+++ b/handler/authorize.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/go-kit/kit/metrics"
+	"github.com/gorilla/sessions"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -19,6 +20,7 @@ const (
 
 var (
 	BadCredentialsJson = map[string]string{"message": "Bad credentials"}
+	cookieStore        = sessions.NewCookieStore([]byte("secret"))
 )
 
 type LoginStore interface {

--- a/handler/authorize_test.go
+++ b/handler/authorize_test.go
@@ -15,7 +15,8 @@ func TestAuthorize(t *testing.T) {
 	res, content, err := Request(r, http.MethodPost, "/api/authorize", []byte(payload))
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
-	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	assert.Equal(t, "application/json; charset=utf-8", res.Header.Get("Content-Type"))
+	assert.Contains(t, res.Header.Get("Set-Cookie"), "_gitpods_session=")
 	assert.Equal(t,
 		`{"id":"25558000-2565-48dc-84eb-18754da2b0a2","username":"metalmatze","name":"Matthias Loibl","email":"metalmatze@example.com"}`,
 		string(content),
@@ -28,7 +29,7 @@ func TestAuthorizeBadRequest(t *testing.T) {
 	res, content, err := Request(r, http.MethodPost, "/api/authorize", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
-	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	assert.Equal(t, "application/json; charset=utf-8", res.Header.Get("Content-Type"))
 	assert.Equal(t, `{"message":"failed to unmarshal form"}`, string(content))
 }
 
@@ -40,7 +41,7 @@ func TestAuthorizeWrongEmail(t *testing.T) {
 	res, content, err := Request(r, http.MethodPost, "/api/authorize", []byte(payload))
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	assert.Equal(t, "application/json; charset=utf-8", res.Header.Get("Content-Type"))
 	assert.Equal(t, `{"message":"Bad credentials"}`, string(content))
 }
 
@@ -52,6 +53,6 @@ func TestAuthorizeWrongPassword(t *testing.T) {
 	res, content, err := Request(r, http.MethodPost, "/api/authorize", []byte(payload))
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
-	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	assert.Equal(t, "application/json; charset=utf-8", res.Header.Get("Content-Type"))
 	assert.Equal(t, `{"message":"Bad credentials"}`, string(content))
 }

--- a/handler/router.go
+++ b/handler/router.go
@@ -27,7 +27,7 @@ type RouterMetrics struct {
 	LoginAttempts metrics.Counter
 }
 
-func NewRouter(logger log.Logger, metrics RouterMetrics, box packr.Box, store Store) *mux.Router {
+func NewRouter(logger log.Logger, metrics RouterMetrics, box packr.Box, store Store) http.Handler {
 	r := mux.NewRouter().StrictSlash(true)
 
 	// instantiate default middlewares
@@ -59,6 +59,9 @@ func NewRouter(logger log.Logger, metrics RouterMetrics, box packr.Box, store St
 	}
 
 	r.NotFoundHandler = HomeHandler(box)
+
+	// TODO: Wrap your handlers with context.ClearHandler as or else you will leak memory!
+	//r = gorillacontext.ClearHandler(handler)
 
 	return r
 }

--- a/handler/router_test.go
+++ b/handler/router_test.go
@@ -14,10 +14,9 @@ import (
 	"github.com/go-kit/kit/metrics/discard"
 	"github.com/gobuffalo/packr"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
 	"github.com/stretchr/testify/assert"
 )
-
-const NotFoundJsonString = `{"error":"Not Found"}`
 
 var (
 	box            = packr.NewBox("../public")
@@ -25,7 +24,7 @@ var (
 )
 
 func TestApiNotFound(t *testing.T) {
-	r := DefaultTestRouter()
+	r := DefaultTestAuthRouter()
 	res, content, err := Request(r, http.MethodGet, "/api/404", nil)
 	assert.NoError(t, err)
 	assertNotFoundJson(t, res, content)
@@ -40,8 +39,27 @@ func DiscardMetrics() handler.RouterMetrics {
 }
 
 func DefaultTestRouter() *mux.Router {
+	return DefaultTestRouterWithStore(DefaultRouterStore())
+}
+
+func DefaultTestRouterWithStore(store handler.RouterStore) *mux.Router {
+	return handler.NewRouter(log.NewNopLogger(), DiscardMetrics(), box, store)
+}
+func DefaultTestAuthRouter() *mux.Router {
+	return DefaultTestAuthRouterWithStore(DefaultRouterStore())
+}
+
+func DefaultTestAuthRouterWithStore(store handler.RouterStore) *mux.Router {
+	return handler.NewAuthRouter(log.NewNopLogger(), DiscardMetrics(), store)
+}
+
+func DefaultRouterStore() handler.RouterStore {
 	userStore := store.NewUserInMemory()
-	return handler.NewRouter(log.NewNopLogger(), DiscardMetrics(), box, userStore)
+	return handler.RouterStore{
+		LoginStore:  userStore,
+		UserStore:   userStore,
+		CookieStore: sessions.NewCookieStore([]byte("secret")),
+	}
 }
 
 func Request(r *mux.Router, method string, url string, payload []byte) (*http.Response, []byte, error) {
@@ -64,8 +82,14 @@ func Request(r *mux.Router, method string, url string, payload []byte) (*http.Re
 	return res, content, nil
 }
 
+func assertUnauthorized(t *testing.T, res *http.Response, content []byte) {
+	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	assert.Equal(t, "application/json; charset=utf-8", res.Header.Get("Content-Type"))
+	assert.JSONEq(t, `{"message":"Unauthorized"}`, string(content))
+}
+
 func assertNotFoundJson(t *testing.T, res *http.Response, content []byte) {
 	assert.Equal(t, http.StatusNotFound, res.StatusCode)
-	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
-	assert.JSONEq(t, NotFoundJsonString, string(content))
+	assert.Equal(t, "application/json; charset=utf-8", res.Header.Get("Content-Type"))
+	assert.Equal(t, handler.JsonNotFound, content)
 }

--- a/handler/user.go
+++ b/handler/user.go
@@ -25,10 +25,13 @@ func jsonResponse(w http.ResponseWriter, v interface{}, code int) {
 		http.Error(w, "failed to marshal to json", http.StatusInternalServerError)
 		return
 	}
+	jsonResponseBytes(w, data, code)
+}
 
+func jsonResponseBytes(w http.ResponseWriter, payload []byte, code int) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
-	w.Write(data)
+	w.Write(payload)
 }
 
 func UserList(logger log.Logger, store UserStore) http.HandlerFunc {
@@ -50,7 +53,7 @@ func User(logger log.Logger, store UserStore) http.HandlerFunc {
 
 		user, err := store.GetUser(username)
 		if err != nil {
-			jsonResponse(w, NotFoundJson, http.StatusNotFound)
+			jsonResponseBytes(w, JsonNotFound, http.StatusNotFound)
 			return
 		}
 
@@ -112,7 +115,7 @@ func UserUpdate(logger log.Logger, s UserStore) http.HandlerFunc {
 
 		user, err := s.UpdateUser(username, user)
 		if err == store.UserNotFound {
-			jsonResponse(w, NotFoundJson, http.StatusNotFound)
+			jsonResponseBytes(w, JsonNotFound, http.StatusNotFound)
 			return
 		}
 
@@ -129,7 +132,7 @@ func UserDelete(logger log.Logger, s UserStore) http.HandlerFunc {
 
 		err := s.DeleteUser(username)
 		if err == store.UserNotFound {
-			jsonResponse(w, NotFoundJson, http.StatusNotFound)
+			jsonResponseBytes(w, JsonNotFound, http.StatusNotFound)
 			return
 		}
 		if err != nil {

--- a/ui/login.vue
+++ b/ui/login.vue
@@ -58,7 +58,8 @@
 				this.failed = false; // reset the alert for a new try
 				this.$store.dispatch('authenticateUser', {email: this.email, password: this.password})
 					.then((user) => {
-						this.$router.push('/');
+						// We actually need to reload the page, so we can use the cookie.
+						window.location.replace('/');
 					})
 					.catch((err) => {
 						if (err.response.status === 401) {

--- a/ui/store.js
+++ b/ui/store.js
@@ -45,14 +45,16 @@ export const store = new Vuex.Store({
 	},
 	actions: {
 		fetchAuthenticatedUser(ctx) {
-			axios.get(`/api/user`)
-				.then((res) => {
-					ctx.commit('setUser', res.data);
-					resolve(res.data);
-				})
-				.catch((err) => {
-					reject(err);
-				})
+			return new Promise((resolve, reject) => {
+				axios.get(`/api/user`)
+					.then((res) => {
+						ctx.commit('setUser', res.data);
+						resolve(res.data);
+					})
+					.catch((err) => {
+						reject(err);
+					})
+			})
 		},
 		authenticateUser(ctx, payload) {
 			return new Promise((resolve, reject) => {


### PR DESCRIPTION
I've introduced `func AuthRouter` which creates a new `*mux.Router` that is injected into the Authorized middleware in the main router.
Like that the routes are guarded with cookies but are testable from within (the test code) nevertheless.